### PR TITLE
Estilización de reporte

### DIFF
--- a/src/shared/components/sections/reporteUsuario/index.js
+++ b/src/shared/components/sections/reporteUsuario/index.js
@@ -1,8 +1,8 @@
 /* eslint max-len: [2, 500, 4] */
-const style = require('./style.scss');
-
 import React from 'react';
 import _ from 'lodash';
+
+const style = require('./style.scss');
 
 import TweetsBlock from './tweetsBlock';
 import QuestionEntry from './questionEntry';
@@ -58,7 +58,7 @@ export default class ReporteUsuarioSection extends React.Component {
     } else if (this.state.view === 'QUESTION_SAVE') {
       content = (<TweetsBlock clickHandler={this.clickHandler} />);
     }
-    return (<div className="container-fluid">
+    return (<div className={style.report}>
       {content}
     </div>);
   }

--- a/src/shared/components/sections/reporteUsuario/questionEntry.js
+++ b/src/shared/components/sections/reporteUsuario/questionEntry.js
@@ -24,36 +24,36 @@ export default class QuestionPort extends React.Component {
 
   render() {
     return (<div className="container-fluid">
-      Por dónde cruzas?
       <div className="row">
         <div className="col-sm-12">
-          San Ysidrio
+          <h2 className={style.heading2}>Por dónde cruzas?</h2>
+          <h3 className={style.heading3}>San Ysidrio</h3>
         </div>
-        <div className="col-sm-4">
+        <div className="col-xs-4">
           <ClickOption className={style.btn_option} value="san_ysidro::carro::normal" clickHandler={this.clickHandler}>
             <SVG network="normal-lane" />
             Normal
           </ClickOption>
         </div>
-        <div className="col-sm-4">
+        <div className="col-xs-4">
           <ClickOption className={style.btn_option} value="san_ysidro::caro::ready_lane" clickHandler={this.clickHandler}>
             <SVG network="ready-lane" />
             R. Lane
           </ClickOption>
         </div>
-        <div className="col-sm-4">
+        <div className="col-xs-4">
           <ClickOption className={style.btn_option} value="san_ysidro::carro::sentri" clickHandler={this.clickHandler}>
             <SVG network="sentry-lane" />
             Sentri
           </ClickOption>
         </div>
-        <div className="col-sm-4">
+        <div className="col-xs-4">
           <ClickOption className={style.btn_option} value="san_ysidro::peatonal::normal" clickHandler={this.clickHandler}>
             <SVG network="normal-ped" />
             Normal
           </ClickOption>
         </div>
-        <div className="col-sm-4">
+        <div className="col-xs-4">
           <ClickOption className={style.btn_option} value="san_ysidro::peatonal::ready_lane" clickHandler={this.clickHandler}>
             <SVG network="ready-ped" />
             R. Lane
@@ -63,33 +63,33 @@ export default class QuestionPort extends React.Component {
 
       <div className="row">
         <div className="col-sm-12">
-          Otay
+          <h3 className={style.heading3}>Otay</h3>
         </div>
-        <div className="col-sm-4">
+        <div className="col-xs-4">
           <ClickOption className={style.btn_option} value="otay::carro::normal" clickHandler={this.clickHandler}>
             <SVG network="normal-lane" />
             Normal
           </ClickOption>
         </div>
-        <div className="col-sm-4">
+        <div className="col-xs-4">
           <ClickOption className={style.btn_option} value="otay::carro::ready_lane" clickHandler={this.clickHandler}>
             <SVG network="ready-lane" />
             R. Lane
           </ClickOption>
         </div>
-        <div className="col-sm-4">
+        <div className="col-xs-4">
           <ClickOption className={style.btn_option} value="otay::carro::sentri" clickHandler={this.clickHandler}>
             <SVG network="sentry-lane" />
             Sentri
           </ClickOption>
         </div>
-        <div className="col-sm-4">
+        <div className="col-xs-4">
           <ClickOption className={style.btn_option} value="otay::peatonal::normal" clickHandler={this.clickHandler}>
             <SVG network="normal-ped" />
             Normal
           </ClickOption>
         </div>
-        <div className="col-sm-4">
+        <div className="col-xs-4">
           <ClickOption className={style.btn_option} value="otay::peatonal::ready_lane" clickHandler={this.clickHandler}>
             <SVG network="ready-ped" />
             R.Lane

--- a/src/shared/components/sections/reporteUsuario/questionPlace.js
+++ b/src/shared/components/sections/reporteUsuario/questionPlace.js
@@ -32,28 +32,28 @@ export default class QuestionPlace extends React.Component {
   renderSanYsidrio() {
     return (<div className="row">
       ¿A qué altura estas?
-      <div className="col-sm-12">
-        <ClickOption className={style.btn_wide} value="place_a" clickHandler={this.clickHandler}>
+      <div className="col-xs-12">
+        <ClickOption className={style.btn_option} value="place_a" clickHandler={this.clickHandler}>
           A menos de 10 carros
         </ClickOption>
       </div>
-      <div className="col-sm-12">
-        <ClickOption className={style.btn_wide} value="place_b" clickHandler={this.clickHandler}>
+      <div className="col-xs-12">
+        <ClickOption className={style.btn_option} value="place_b" clickHandler={this.clickHandler}>
           En el puente de las ballenas
         </ClickOption>
       </div>
-      <div className="col-sm-12">
-        <ClickOption className={style.btn_wide} value="place_c" clickHandler={this.clickHandler}>
+      <div className="col-xs-12">
+        <ClickOption className={style.btn_option} value="place_c" clickHandler={this.clickHandler}>
           Por el Palacio Municipal
         </ClickOption>
       </div>
-      <div className="col-sm-12">
-        <ClickOption className={style.btn_wide} value="place_d" clickHandler={this.clickHandler}>
+      <div className="col-xs-12">
+        <ClickOption className={style.btn_option} value="place_d" clickHandler={this.clickHandler}>
           Por el Hospital General
         </ClickOption>
       </div>
-      <div className="col-sm-12">
-        <ClickOption className={style.btn_wide} value="place_e" clickHandler={this.clickHandler}>
+      <div className="col-xs-12">
+        <ClickOption className={style.btn_option} value="place_e" clickHandler={this.clickHandler}>
           Por la 20 de noviembre
         </ClickOption>
       </div>
@@ -62,29 +62,29 @@ export default class QuestionPlace extends React.Component {
 
   renderOtay() {
     return (<div className="row">
-      ¿A qué altura estas?
-      <div className="col-sm-12">
-        <ClickOption className={style.btn_wide} value="place_a" clickHandler={this.clickHandler}>
+      <h2 className={style.heading2}>¿A qué altura estas?</h2>
+      <div className="col-xs-12">
+        <ClickOption className={style.btn_option} value="place_a" clickHandler={this.clickHandler}>
           A menos de 10 carros
         </ClickOption>
       </div>
-      <div className="col-sm-12">
-        <ClickOption className={style.btn_wide} value="place_b" clickHandler={this.clickHandler}>
+      <div className="col-xs-12">
+        <ClickOption className={style.btn_option} value="place_b" clickHandler={this.clickHandler}>
           En el puente
         </ClickOption>
       </div>
-      <div className="col-sm-12">
-        <ClickOption className={style.btn_wide} value="place_c" clickHandler={this.clickHandler}>
+      <div className="col-xs-12">
+        <ClickOption className={style.btn_option} value="place_c" clickHandler={this.clickHandler}>
           En la frutería
         </ClickOption>
       </div>
-      <div className="col-sm-12">
-        <ClickOption className={style.btn_wide} value="place_d" clickHandler={this.clickHandler}>
+      <div className="col-xs-12">
+        <ClickOption className={style.btn_option} value="place_d" clickHandler={this.clickHandler}>
           En los mariscos
         </ClickOption>
       </div>
-      <div className="col-sm-12">
-        <ClickOption className={style.btn_wide} value="place_e" clickHandler={this.clickHandler}>
+      <div className="col-xs-12">
+        <ClickOption className={style.btn_option} value="place_e" clickHandler={this.clickHandler}>
           En el parque de la amistad
         </ClickOption>
       </div>
@@ -96,7 +96,9 @@ export default class QuestionPlace extends React.Component {
     return (<div className="container-fluid">
       { port === 'san_ysidro' ? this.renderSanYsidrio() : this.renderOtay() }
       <div className="row">
-        <a onClick={this.backHandler}>Volver</a>
+        <div className="col-xs-12">
+          <a onClick={this.backHandler} className={style.prevStep}>Volver</a>
+        </div>
       </div>
     </div>);
   }

--- a/src/shared/components/sections/reporteUsuario/questionReview.js
+++ b/src/shared/components/sections/reporteUsuario/questionReview.js
@@ -96,26 +96,34 @@ export default class QuestionReview extends React.Component {
     return (<div className="container-fluid">
       <div className="row">
         <div className="col-sm-12">
-          <p>Por dónde cruzas?</p>
-          {this.renderPort(data.port)}
-          {this.renderEntry(data.entry, data.type)}
+          <h2 className={style.heading2}>Por dónde cruzas?</h2>
+          <h3 className={style.heading3}>
+            {this.renderPort(data.port)}
+            {this.renderEntry(data.entry, data.type)}
+          </h3>
         </div>
         <div className="col-sm-12">
-          <p>A qué altura estas?</p>
-          {this.renderPlace(data.place)}
+          <h2 className={style.heading2}>A qué altura estas?</h2>
+          <h3 className={style.heading3}>
+            {this.renderPlace(data.place)}
+          </h3>
         </div>
         <div className="col-sm-12">
-          <p>Cuánto tiempo llevas esperando?</p>
-          {this.renderTime(data.time)}
+          <h2 className={style.heading2}>Cuánto tiempo llevas esperando?</h2>
+          <h3 className={style.heading3}>
+            {this.renderTime(data.time)}
+          </h3>
         </div>
         <div className="col-sm-12">
-          <ClickOption clickHandler={this.clickHandler} value="" className={style.btn1}>
+          <ClickOption clickHandler={this.clickHandler} value="" className={style.btn_publish}>
             Publicar
           </ClickOption>
         </div>
       </div>
       <div className="row">
-        <a onClick={this.backHandler}>Volver</a>
+        <div className="col-xs-12">
+          <a onClick={this.backHandler} className={style.prevStep}>Volver</a>
+        </div>
       </div>
       <div className="form-group">
         <span className={ this.state.status !== true ? 'text-danger' : 'text-success' }>{this.state.formMessage}</span>

--- a/src/shared/components/sections/reporteUsuario/questionTime.js
+++ b/src/shared/components/sections/reporteUsuario/questionTime.js
@@ -27,51 +27,53 @@ export default class QuestionTime extends React.Component {
 
   render() {
     return (<div className="container-fluid">
-      Cuánto tiempo llevas esperando?
+      <h2 className={style.heading2}>Cuánto tiempo llevas esperando?</h2>
       <div className="row">
-        <div className="col-sm-6">
-          <ClickOption value="15_mins" clickHandler={this.clickHandler} className={style.btn_wide}>
+        <div className="col-xs-6">
+          <ClickOption value="15_mins" clickHandler={this.clickHandler} className={style.btn_option}>
             0:15
           </ClickOption>
         </div>
-        <div className="col-sm-6">
-          <ClickOption value="30_mins" clickHandler={this.clickHandler} className={style.btn_wide}>
+        <div className="col-xs-6">
+          <ClickOption value="30_mins" clickHandler={this.clickHandler} className={style.btn_option}>
             0:30
           </ClickOption>
         </div>
-        <div className="col-sm-6">
-          <ClickOption value="1_hra" clickHandler={this.clickHandler} className={style.btn_wide}>
+        <div className="col-xs-6">
+          <ClickOption value="1_hra" clickHandler={this.clickHandler} className={style.btn_option}>
             1:00
           </ClickOption>
         </div>
-        <div className="col-sm-6">
-          <ClickOption value="1:30_hra" clickHandler={this.clickHandler} className={style.btn_wide}>
+        <div className="col-xs-6">
+          <ClickOption value="1:30_hra" clickHandler={this.clickHandler} className={style.btn_option}>
             1:30
           </ClickOption>
         </div>
-        <div className="col-sm-6">
-          <ClickOption value="2_hrs" clickHandler={this.clickHandler} className={style.btn_wide}>
+        <div className="col-xs-6">
+          <ClickOption value="2_hrs" clickHandler={this.clickHandler} className={style.btn_option}>
             2:00
           </ClickOption>
         </div>
-        <div className="col-sm-6">
-          <ClickOption value="3_hrs" clickHandler={this.clickHandler} className={style.btn_wide}>
+        <div className="col-xs-6">
+          <ClickOption value="3_hrs" clickHandler={this.clickHandler} className={style.btn_option}>
             3:00
           </ClickOption>
         </div>
-        <div className="col-sm-6">
-          <ClickOption value="4_hrs" clickHandler={this.clickHandler} className={style.btn_wide}>
+        <div className="col-xs-6">
+          <ClickOption value="4_hrs" clickHandler={this.clickHandler} className={style.btn_option}>
             4:00
           </ClickOption>
         </div>
-        <div className="col-sm-6">
-          <ClickOption value="ya_vivo_aqui" clickHandler={this.clickHandler} className={style.btn_wide}>
+        <div className="col-xs-6">
+          <ClickOption value="ya_vivo_aqui" clickHandler={this.clickHandler} className={style.btn_option}>
             ya vivo aquí
           </ClickOption>
         </div>
       </div>
       <div className="row">
-        <a onClick={this.backHandler}>Volver</a>
+        <div className="col-xs-12">
+          <a onClick={this.backHandler} className={style.prevStep}>Volver</a>
+        </div>
       </div>
     </div>);
   }

--- a/src/shared/components/sections/reporteUsuario/style.scss
+++ b/src/shared/components/sections/reporteUsuario/style.scss
@@ -1,6 +1,12 @@
 @import '../../../theme/constants.scss';
 @import '../../../theme/buttons/buttons.scss';
 
+.report {
+  background: $cyan;
+  text-align: center;
+  padding-top: 15px;
+}
+
 .btn_report {
   @extend .btn1;
   background: $cyan;
@@ -12,10 +18,29 @@
     font-weight: bold;
   }
 }
+
+.heading2 {
+  color: $white;
+  font-size: 18px;
+  text-align: center;
+  font-weight: normal;
+  margin-bottom: 20px;
+}
+
+.heading3 {
+  color: $darkBlue;
+  font-size: 24px;
+  font-weight: bold;
+  margin-bottom: 15px;
+}
+
 .btn_option {
   @extend .btn1;
   background: #fff;
   color: $darkBlue;
+  width: 100%;
+  padding-right: 12px;
+  padding-left: 12px;
 
   svg {
     display: block;
@@ -26,7 +51,32 @@
     color: $darkBlue;
   }
 }
-.btn_wide {
+
+.btn_publish {
   @extend .btn_option;
-  width: 100%;
+  display: inline-block;
+  font-size: 28px;
+  width: auto;
+}
+
+.prevStep {
+  color: $darkBlue;
+  position: relative;
+  display: block;
+  font-size: 18px;
+  text-align: left;
+  padding: 15px;
+
+  &::before {
+    content: "";
+    width: 0;
+    height: 0;
+    border-top: 5px solid transparent;
+    border-bottom: 5px solid transparent;
+    border-right: 5px solid $darkBlue;
+    position: absolute;
+    left: 0;
+
+    @extend .vCenter;
+  }
 }

--- a/src/shared/components/sections/reporteUsuario/tweetsBlock.js
+++ b/src/shared/components/sections/reporteUsuario/tweetsBlock.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import _ from 'lodash';
 
-import RequestUtil from '../../../utils/requestUtil';
+// import RequestUtil from '../../../utils/requestUtil';
 import { timeSince } from '../../../utils/string';
 
+const style = require('./style.scss');
 
 export default class TweetsBlock extends React.Component {
 
@@ -15,20 +16,20 @@ export default class TweetsBlock extends React.Component {
     };
   }
 
-  componentDidMount() {
-    RequestUtil.get('/user/report')
-      .then((results) => {
-        if (_.isArray(results.entity) && results.entity.length) {
-          const tweets = _.sortBy(results.entity, (item) => {
-            return new Date(item.created_at);
-          }).reverse();
-          const newState = _.assign({}, this.state, {
-            tweets,
-          });
-          this.setState(newState);
-        }
-      });
-  }
+  // componentDidMount() {
+  //   RequestUtil.get('/user/report')
+  //     .then((results) => {
+  //       if (_.isArray(results.entity) && results.entity.length) {
+  //         const tweets = _.sortBy(results.entity, (item) => {
+  //           return new Date(item.created_at);
+  //         }).reverse();
+  //         const newState = _.assign({}, this.state, {
+  //           tweets,
+  //         });
+  //         this.setState(newState);
+  //       }
+  //     });
+  // }
 
   clickHandler() {
     this.props.clickHandler('QUESTION_ENTRY', {});
@@ -48,7 +49,11 @@ export default class TweetsBlock extends React.Component {
 
   render() {
     return (<div>
-      <a className="btn btn-default" onClick={this.clickHandler}>Reportar</a>
+      <a className={style.btn_report} onClick={this.clickHandler}>¿Cómo te va en la línea?
+        <span className={style.subtitle}>
+          Repórtalo aquí y ayuda a los demás
+        </span>
+      </a>
       <br />
       { this.renderTweets(this.state.tweets) }
     </div>);

--- a/src/shared/theme/buttons/buttons.scss
+++ b/src/shared/theme/buttons/buttons.scss
@@ -7,7 +7,7 @@
   display: inline-block;
   font-size: 16px;
   font-weight: bold;
-  margin-bottom: 50px;
+  margin-bottom: 20px;
   padding: 16px;
   position: relative;
   text-align: center;


### PR DESCRIPTION
Se implementó estilo en todos los botones de selección, títulos y botón de volver.

Hace falta:
- que el reviewReport muestre títulos e iconos en lugar de variables.
- Barra de breadcrums de progreso.
- Cruz para cerrar el reporte.
- Ocultar header y footer.
